### PR TITLE
Make representer fail gracefully

### DIFF
--- a/src/clojure_representer/main.clj
+++ b/src/clojure_representer/main.clj
@@ -24,7 +24,7 @@
                 nofollow-links
                 (conj LinkOption/NOFOLLOW_LINKS))))
 
-(defn normalize 
+(defn normalize
   "Takes a Java.io.File containing Clojure code
    and outputs a string representing a normalized, 
    fully macroexpanded version of itself."
@@ -41,10 +41,14 @@
   (let [file           (str (str/replace slug "-" "_") ".clj")
         _              (reset! placeholder 0)
         _              (reset! mappings {})
-        representation (-> (io/file in-dir file)
-                           normalize
-                           z/of-string
-                           z/sexpr)]
+        representation (try
+                         (-> (io/file in-dir file)
+                             normalize
+                             z/of-string
+                             z/sexpr)
+                         (catch Exception e
+                           (str "Exception in file "
+                                in-dir file ": " (.getMessage e))))]
     (spit (str (io/file out-dir "mapping.json"))
           (json/write-str (into {} (map (fn [[k v]] [v k]) @mappings))))
     (spit (str (io/file out-dir "representation.txt"))


### PR DESCRIPTION
Before we even think about launching this, I needed to add error handling.

If an exception occurs during evaluation, it is caught and reported in `representation.txt` along with the file path.

Is that what we want to happen? Or should it just perform a no-op and output the solution as is?