### PR TITLE
Output file with representer version

### DIFF
--- a/src/clojure_representer/main.clj
+++ b/src/clojure_representer/main.clj
@@ -97,7 +97,9 @@
     (spit (str (io/file out-dir "mapping.json"))
           (json/write-str (into {} (map (fn [[k v]] [v k]) @mappings))))
     (spit (str (io/file out-dir "representation.txt"))
-          (with-out-str (pp/pprint representation)))))
-  
+          (with-out-str (pp/pprint representation)))
+    (spit (str (io/file out-dir "representation.json"))
+          (json/write-str {:version 1}))))
+
 (defn -main [slug in-dir out-dir]
   (represent {:slug slug :in-dir in-dir :out-dir out-dir}))


### PR DESCRIPTION
I was reviewing the spec to see if there was anything I missed because the representer does not seem to be live yet. I'm not sure if this would be the issue (it says the version defaults to 1 anyway) but now it outputs the file.